### PR TITLE
fix: Portfolio website Title

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,7 +31,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>Portfolio - Shehryar Ahmed</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
fixes #2 

What does this PR do?

This pull request modifies the name of the portfolio website from the default React app name to a more relevant name.

screenshots:
![image](https://github.com/shehryardev/reactjs-portfolio/assets/123088024/96cf3220-e17c-4164-891b-b96f9ec852cc)

